### PR TITLE
feat: add Helium browser support

### DIFF
--- a/Sources/SweetCookieKit/BrowserCookieModels.swift
+++ b/Sources/SweetCookieKit/BrowserCookieModels.swift
@@ -24,6 +24,7 @@ public enum Browser: String, Sendable, Hashable, CaseIterable {
     case edgeBeta
     case edgeCanary
     case vivaldi
+    case helium
 
     /// Display name for UI or logs.
     public var displayName: String {
@@ -45,6 +46,7 @@ public enum Browser: String, Sendable, Hashable, CaseIterable {
         case .edgeBeta: "Microsoft Edge Beta"
         case .edgeCanary: "Microsoft Edge Canary"
         case .vivaldi: "Vivaldi"
+        case .helium: "Helium"
         }
     }
 
@@ -59,6 +61,7 @@ public enum Browser: String, Sendable, Hashable, CaseIterable {
         .chatgptAtlas,
         .chromium,
         .vivaldi,
+        .helium,
         .firefox,
         .chromeBeta,
         .chromeCanary,

--- a/Sources/SweetCookieKit/ChromeCookieImporter.swift
+++ b/Sources/SweetCookieKit/ChromeCookieImporter.swift
@@ -209,6 +209,7 @@ enum ChromeCookieImporter {
             ("com.openai.atlas Safe Storage", "com.openai.atlas"),
             ("Microsoft Edge Safe Storage", "Microsoft Edge"),
             ("Vivaldi Safe Storage", "Vivaldi"),
+            ("Helium Safe Storage", "Helium"),
         ]
 
         if let context = Self.preflightSafeStoragePrompt(labels: labels) {
@@ -459,6 +460,8 @@ enum ChromeCookieImporter {
             "Microsoft Edge Canary"
         case .vivaldi:
             "Vivaldi"
+        case .helium:
+            "Helium/User Data"
         case .safari, .firefox:
             ""
         }


### PR DESCRIPTION
## Summary

This PR adds support for the Helium browser (a Chromium-based browser) to enable cookie extraction.

## Changes

### BrowserCookieModels.swift
- Added `helium` case to the `Browser` enum
- Added `"Helium"` display name
- Added `.helium` to `defaultImportOrder`

### ChromeCookieImporter.swift
- Added `("Helium Safe Storage", "Helium")` to Keychain labels for cookie decryption
- Added `"Helium/User Data"` path for cookie database discovery

## Technical Details

Helium follows the standard Chromium User Data directory structure:
```
~/Library/Application Support/Helium/User Data/[Profile]/
```

Cookie database is located at:
```
~/Library/Application Support/Helium/User Data/[Profile]/Cookies
```

Keychain entry for decryption:
- Service: `Helium Safe Storage`
- Account: `Helium`

## Test Plan

- [ ] Verify Helium browser is detected when installed
- [ ] Confirm cookies are extracted from Helium profiles
- [ ] Test Keychain access for cookie decryption

🤖 Generated with [Claude Code](https://claude.com/claude-code)