### PR TITLE
feat: add Perplexity Comet browser support

### DIFF
--- a/Sources/SweetCookieKit/BrowserCatalog.swift
+++ b/Sources/SweetCookieKit/BrowserCatalog.swift
@@ -209,6 +209,14 @@ enum BrowserCatalog {
                 chromiumProfileRelativePath: "Microsoft Edge Canary",
                 geckoProfilesFolder: nil,
                 safeStorageLabels: []),
+            BrowserMetadata(
+                browser: .comet,
+                displayName: "Comet",
+                engine: .chromium,
+                defaultImportOrderRank: 20,
+                chromiumProfileRelativePath: "Comet",
+                geckoProfilesFolder: nil,
+                safeStorageLabels: [("Comet Safe Storage", "Comet")]),
         ]
 
         var map: [Browser: BrowserMetadata] = [:]
@@ -247,6 +255,7 @@ enum BrowserCatalog {
             .edge,
             .vivaldi,
             .dia,
+            .comet,
         ]
         return labelOrder.flatMap { metadata(for: $0).safeStorageLabels }
     }()

--- a/Sources/SweetCookieKit/BrowserCookieModels.swift
+++ b/Sources/SweetCookieKit/BrowserCookieModels.swift
@@ -27,6 +27,7 @@ public enum Browser: String, Sendable, Hashable, CaseIterable {
     case helium
     case vivaldi
     case dia
+    case comet
 
     /// Display name for UI or logs.
     public var displayName: String {


### PR DESCRIPTION
## Summary
- Add `comet` case to `Browser` enum for the Perplexity Comet browser (Chromium-based)
- Add metadata in `BrowserCatalog` with profile path `Comet`, safe storage labels `("Comet Safe Storage", "Comet")`, and rank 20
- Include Comet in the `safeStorageLabels` label order

## Context
Comet is a Chromium-based browser by Perplexity AI, available on macOS since July 2025. It stores profile data at `~/Library/Application Support/Comet/` with standard Chromium `Default/` profile structure and Keychain safe storage.

This change is needed to enable cookie import support for Comet in CodexBar.

Made with [Cursor](https://cursor.com)