### PR TITLE
Fix Helium cookie decryption: correct keychain label + per-browser key cache

### DIFF
--- a/Sources/SweetCookieKit/BrowserCatalog.swift
+++ b/Sources/SweetCookieKit/BrowserCatalog.swift
@@ -114,8 +114,7 @@ enum BrowserCatalog {
                 chromiumProfileRelativePath: "net.imput.helium",
                 geckoProfilesFolder: nil,
                 safeStorageLabels: [
-                    ("Helium Safe Storage", "Helium"),
-                    ("net.imput.helium Safe Storage", "net.imput.helium"),
+                    ("Helium Storage Key", "Helium"),
                 ]),
             BrowserMetadata(
                 browser: .vivaldi,

--- a/Sources/SweetCookieKit/ChromeCookieImporter.swift
+++ b/Sources/SweetCookieKit/ChromeCookieImporter.swift
@@ -13,7 +13,7 @@ import SQLite3
 ///   AES-CBC + PBKDF2. This is inherently brittle across Chromium changes; keep it best-effort.
 enum ChromeCookieImporter {
     private static let chromeSafeStorageKeyLock = NSLock()
-    private nonisolated(unsafe) static var cachedChromeSafeStorageKey: Data?
+    private nonisolated(unsafe) static var cachedSafeStorageKeys: [Browser: Data] = [:]
 
     enum ImportError: LocalizedError {
         case cookieDBNotFound(path: String)
@@ -73,7 +73,7 @@ enum ChromeCookieImporter {
         guard let sourceDB = store.databaseURL else {
             throw ImportError.cookieDBNotFound(path: "Missing cookie DB for \(store.label)")
         }
-        let chromeKey = try Self.chromeSafeStorageKey()
+        let chromeKey = try Self.chromeSafeStorageKey(for: store.browser)
         return try Self.readCookiesFromLockedChromeDB(
             sourceDB: sourceDB,
             key: chromeKey,
@@ -191,19 +191,19 @@ enum ChromeCookieImporter {
 
     // MARK: - Keychain + crypto
 
-    private static func chromeSafeStorageKey() throws -> Data {
+    private static func chromeSafeStorageKey(for browser: Browser) throws -> Data {
         if BrowserCookieKeychainAccessGate.isDisabled {
             throw ImportError.keychainDenied
         }
 
         self.chromeSafeStorageKeyLock.lock()
-        if let cached = self.cachedChromeSafeStorageKey {
+        if let cached = self.cachedSafeStorageKeys[browser] {
             self.chromeSafeStorageKeyLock.unlock()
             return cached
         }
         self.chromeSafeStorageKeyLock.unlock()
 
-        let labels = BrowserCatalog.safeStorageLabels
+        let labels = browser.safeStorageLabels
 
         if let context = Self.preflightSafeStoragePrompt(labels: labels) {
             BrowserCookieKeychainPromptHandler.handler?(context)
@@ -246,7 +246,7 @@ enum ChromeCookieImporter {
         }
 
         self.chromeSafeStorageKeyLock.lock()
-        self.cachedChromeSafeStorageKey = key
+        self.cachedSafeStorageKeys[browser] = key
         self.chromeSafeStorageKeyLock.unlock()
         return key
     }


### PR DESCRIPTION
## Summary

Fixes two bugs preventing Helium browser cookie decryption. Closes #7.

### Bug 1: Wrong keychain service name for Helium

Helium's Chromium patch (`patches/helium/macos/change-keychain-name.patch` in [imputnet/helium-macos](https://github.com/imputnet/helium-macos)) sets `kDefaultServiceName` to `"Helium Storage Key"`, not `"Helium Safe Storage"`.

The existing labels `("Helium Safe Storage", "Helium")` and `("net.imput.helium Safe Storage", "net.imput.helium")` never match anything in the keychain.

**Fix:** Changed to `("Helium Storage Key", "Helium")`.

### Bug 2: `chromeSafeStorageKey()` uses a shared singleton across all browsers

Each Chromium-based browser generates its own unique Safe Storage password in the macOS Keychain. However, `chromeSafeStorageKey()` iterated through a global label list, cached the **first** key found (typically Chrome's), and reused it for all browsers.

When decrypting Helium's cookies with Chrome's key, decryption silently fails and all cookie records are skipped.

**Fix:** Changed the cache from `Data?` to `[Browser: Data]` and resolved the key using `browser.safeStorageLabels` (per-browser) instead of `BrowserCatalog.safeStorageLabels` (global).

### Changes

- `BrowserCatalog.swift`: Fix Helium `safeStorageLabels` to `[("Helium Storage Key", "Helium")]`
- `ChromeCookieImporter.swift`: Make `chromeSafeStorageKey(for:)` resolve and cache keys per-browser

### Testing

All 40 existing tests pass. Verified on a machine with both Chrome and Helium installed:
- `security dump-keychain` confirms `"Helium Storage Key"` is the actual keychain entry
- Chrome's and Helium's Safe Storage passwords are different strings